### PR TITLE
Add precompile directive

### DIFF
--- a/src/Reexport.jl
+++ b/src/Reexport.jl
@@ -1,12 +1,14 @@
+isdefined(Base, :__precompile__) && __precompile__()
+
 module Reexport
 
 macro reexport(ex)
-    isa(ex, Expr) && (ex.head == :module || 
+    isa(ex, Expr) && (ex.head == :module ||
                       ex.head == :using ||
                       (ex.head == :toplevel &&
                        all(e->isa(e, Expr) && e.head == :using, ex.args))) ||
         error("@reexport: syntax error")
-    
+
     if ex.head == :module
         modules = Any[ex.args[2]]
         ex = Expr(:toplevel, ex, Expr(:using, :., ex.args[2]))
@@ -15,7 +17,7 @@ macro reexport(ex)
     else
         modules = Any[e.args[end] for e in ex.args]
     end
-    
+
     esc(Expr(:toplevel, ex,
              [:(eval(Expr(:export, setdiff(names($(mod)), [mod])...))) for mod in modules]...))
 end


### PR DESCRIPTION
Needed to avoid test failures like
```jl
...
INFO: Recompiling stale cache file /home/travis/.julia/lib/v0.4/DataFrames.ji for module DataFrames.
INFO: Recompiling stale cache file /home/travis/.julia/lib/v0.4/DataArrays.ji for module DataArrays.
WARNING: Module Reexport uuid did not match cache file
WARNING: deserialization checks failed while attempting to load cache from /home/travis/.julia/lib/v0.4/DataArrays.ji
INFO: Recompiling stale cache file /home/travis/.julia/lib/v0.4/DataArrays.ji for module DataArrays.
WARNING: Module Reexport uuid did not match cache file
ERROR: LoadError: LoadError: __precompile__(true) but require failed to create a precompiled cache file
...
```
over at https://travis-ci.org/dcjones/Gadfly.jl/jobs/78317591. (Needs a new release tagged, too.)