### PR TITLE
remove - on julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.2-
+julia 0.2


### PR DESCRIPTION
that refers to prereleases of julia 0.2

If the package isn't being tested on 0.2 any more, then would be better to change this to `julia 0.3`.