### PR TITLE
Fix importall warning (for real this time)

### DIFF
--- a/src/Reexport.jl
+++ b/src/Reexport.jl
@@ -19,7 +19,7 @@ macro reexport(ex)
     end
 
     esc(Expr(:toplevel, ex,
-             [:(eval(Expr(:export, setdiff(names($(mod)), [mod])...))) for mod in modules]...))
+             [:(eval(Expr(:export, setdiff(names($(mod)), [Symbol(string($mod))])...))) for mod in modules]...))
 end
 
 export @reexport

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ module X2
     using Reexport
     @reexport using Y2
 end
-@test union!(Set(), names(X2)) == union!(Set(), [:X2, :Y2, :Z2])
+@test union!(Set(), names(X2)) == union!(Set(), [:X2, :Z2])
 @test X2.Z2 == 2
 
 module X3


### PR DESCRIPTION
I'm not sure if this issue (https://github.com/simonster/Reexport.jl/issues/1) was actually resolved. The warning was persisting for me, I think the issue was that `mod` needed to be interpolated and turned into a symbol.

This PR fixes the problem for me.

``` julia
julia> module A end
julia> module B
           using Reexport
           importall A
           @reexport using A
       end
julia> using B
# nothing but crickets here
```
