### PR TITLE
add Project.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ os:
 julia:
   - 0.5
   - 0.6
+  - 0.7
   - nightly
 notifications:
   email: false
 script:
- - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
- - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("Reexport"); Pkg.test("Reexport"; coverage=true)'
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - julia -e 'if VERSION < v"0.7.0-DEV.5183"; Pkg.clone(pwd()); else; using Pkg; Pkg.add(pwd()); end; Pkg.test("Reexport"; coverage=true)'
 after_success:
-- julia -e 'cd(Pkg.dir("Reexport")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+- julia -e 'VERSION < v"0.7.0-DEV" || (using Pkg); cd(Pkg.dir("Reexport")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,6 @@
+authors = ["Simon Kornblith"]
+name = "Reexport"
+uuid = "49f8cfe4-7840-11e8-1b5d-9125d323f20a"
+version = "0.1.1"
+
+[deps]


### PR DESCRIPTION
I was debugging something in 0.7. (It was it was not related to Reexport.jl in the end)
Debugging things in 0.7 is nicer if you have a Project.toml.
This adds that.