### PR TITLE
Prepare to release version 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.jl.cov
+*.jl.*.cov
+*.jl.mem
+docs/build
+docs/site
+Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
   - 1.1
+  - 1.2
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,10 @@
 name = "Reexport"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
 authors = ["Simon Kornblith <simon@simonster.com>"]
+version = "1.0.0"
+
+[compat]
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,0 @@
-julia 0.7-beta


### PR DESCRIPTION
Changes:
* Add a standard .gitignore file
* Set the Julia compatibility version to ^1.0
* Remove the REQUIRE file
* Replace testing on 0.7 with 1.2
* Set the package version to 1.0.0.

Since Reexport is such a stable package, it makes sense for it to declare itself to be at version 1.0. That way packages which depend on it can specify their version requirement as `Reexport = "1"` without needing to add a new 0.x version of Reexport to their `[compat]` every time one is released.

@simonster, can you add JuliaRegistrator and TagBot for this repository?