### PR TITLE
Make Reexport composable with other import macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,5 @@ using A
 ```
 
 `@reexport @another_macro <import or using expression>` first expands `@another_macro` on the expression, making `@reexport` with other macros.
+
+`@reexport begin ... end` will apply the reexport macro to every expression in the block.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,29 @@ using X
 # all of Y's exported symbols and Z's x and y also available here
 ```
 
+`@reexport import <module>.<name>` or `@reexport import <module>: <name>` exports `<name>` from `<module>` after importing it.
+
+```julia
+module Y
+    ...
+end
+
+module Z
+    ...
+end
+
+module X
+    using Reexport
+    @reexport import Y
+    # Only `Y` itself is available here
+    @reexport import Z: x, y
+    # Z's x and y symbols available here
+end
+
+using X
+# Y (but not it's exported names) and Z's x and y are available here.
+```
+
 `@reexport module <modulename> ... end` defines `module <modulename>` and also re-exports its symbols:
 
 ```julia
@@ -45,3 +68,5 @@ end
 using A
 # all of B's exported symbols available here
 ```
+
+`@reexport @another_macro <import or using expression>` first expands `@another_macro` on the expression, making `@reexport` with other macros.

--- a/src/Reexport.jl
+++ b/src/Reexport.jl
@@ -1,11 +1,20 @@
 module Reexport
 
-macro reexport(ex)
-    isa(ex, Expr) && (ex.head == :module ||
-                      ex.head == :using ||
-                      (ex.head == :toplevel &&
-                       all(e->isa(e, Expr) && e.head == :using, ex.args))) ||
-        error("@reexport: syntax error")
+macro reexport(ex::Expr)
+    esc(reexport(__module__, ex))
+end
+
+function reexport(m::Module, ex::Expr)
+    # unpack any macros
+    ex = macroexpand(m, ex)
+    # recursively unpack any blocks
+    if ex.head == :block
+        return Expr(:block, map(e -> reexport(m, e), ex.args)...)
+    end
+
+    Meta.isexpr(ex, [:module, :using, :import]) ||
+    Meta.isexpr(ex, :toplevel) && all(e->isa(e, Expr) && e.head == :using, ex.args) ||
+    error("@reexport: syntax error")
 
     if ex.head == :module
         modules = Any[ex.args[2]]
@@ -14,15 +23,18 @@ macro reexport(ex)
         modules = Any[ex.args[end]]
     elseif ex.head == :using && ex.args[1].head == :(:)
         symbols = [e.args[end] for e in ex.args[1].args[2:end]]
-        return esc(Expr(:toplevel, ex, :(eval(Expr(:export, $symbols...)))))
+        return Expr(:toplevel, ex, :(eval(Expr(:export, $symbols...))))
+    elseif ex.head == :import
+        symbols = Any[e.args[end] for e in ex.args]
+        return Expr(:toplevel, ex, :(eval(Expr(:export, $symbols...))))
     else
         modules = Any[e.args[end] for e in ex.args]
     end
 
-    esc(Expr(:toplevel, ex,
-             [:(eval(Expr(:export, filter!(x -> Base.isexported($mod, x),
+    Expr(:toplevel, ex,
+         [:(eval(Expr(:export, filter!(x -> Base.isexported($mod, x),
                                            names($mod; all=true, imported=true))...)))
-              for mod in modules]...))
+              for mod in modules]...)
 end
 
 export @reexport

--- a/src/Reexport.jl
+++ b/src/Reexport.jl
@@ -14,13 +14,13 @@ function reexport(m::Module, ex::Expr)
     end
 
     Meta.isexpr(ex, [:module, :using, :import]) ||
-    Meta.isexpr(ex, :toplevel) && all(e->isa(e, Expr) && e.head == :using, ex.args) ||
-    error("@reexport: syntax error")
+        Meta.isexpr(ex, :toplevel) && all(e -> isa(e, Expr) && e.head == :using, ex.args) ||
+        error("@reexport: syntax error")
 
     if ex.head == :module
         modules = Any[ex.args[2]]
         ex = Expr(:toplevel, ex, :(using .$(ex.args[2])))
-    elseif ex.head == :using && all(e->isa(e, Symbol), ex.args)
+    elseif ex.head == :using && all(e -> isa(e, Symbol), ex.args)
         modules = Any[ex.args[end]]
     elseif ex.head == :using && ex.args[1].head == :(:)
         symbols = [e.args[end] for e in ex.args[1].args[2:end]]
@@ -34,8 +34,8 @@ function reexport(m::Module, ex::Expr)
 
     Expr(:toplevel, ex,
          [:(eval(Expr(:export, filter!(x -> Base.isexported($mod, x),
-                                           names($mod; all=true, imported=true))...)))
-              for mod in modules]...)
+                                       names($mod; all=true, imported=true))...)))
+          for mod in modules]...)
 end
 
 export @reexport

--- a/src/Reexport.jl
+++ b/src/Reexport.jl
@@ -9,6 +9,7 @@ function reexport(m::Module, ex::Expr)
     ex = macroexpand(m, ex)
     # recursively unpack any blocks
     if ex.head == :block
+        ex = Base.remove_linenums!(ex)
         return Expr(:block, map(e -> reexport(m, e), ex.args)...)
     end
 

--- a/src/Reexport.jl
+++ b/src/Reexport.jl
@@ -18,18 +18,20 @@ function reexport(m::Module, ex::Expr)
         Meta.isexpr(ex, :toplevel) && all(e -> isa(e, Expr) && e.head == :using, ex.args) ||
         error("@reexport: syntax error")
 
-    if ex.head == :module
+    if Meta.isexpr(ex, :module)
+        # @reexport {using, import} module Foo ... end
         modules = Any[ex.args[2]]
         ex = Expr(:toplevel, ex, :(using .$(ex.args[2])))
-    elseif ex.head == :using && all(e -> isa(e, Symbol), ex.args)
-        modules = Any[ex.args[end]]
-    elseif ex.head == :using && ex.args[1].head == :(:)
+    elseif Meta.isexpr(ex, [:using, :import]) && ex.args[1].head == :(:)
+        # @reexport {using, import} Foo: bar, baz
         symbols = [e.args[end] for e in ex.args[1].args[2:end]]
         return Expr(:toplevel, ex, :(eval(Expr(:export, $symbols...))))
-    elseif ex.head == :import
+    elseif Meta.isexpr(ex, :import) && all(e -> e.head == :(.), ex.args)
+        # @reexport import Foo.bar, Baz.qux
         symbols = Any[e.args[end] for e in ex.args]
         return Expr(:toplevel, ex, :(eval(Expr(:export, $symbols...))))
     else
+        # @reexport using Foo, Bar, Baz
         modules = Any[e.args[end] for e in ex.args]
     end
 

--- a/src/Reexport.jl
+++ b/src/Reexport.jl
@@ -4,12 +4,13 @@ macro reexport(ex::Expr)
     esc(reexport(__module__, ex))
 end
 
+reexport(m::Module, l::LineNumberNode) = l
+
 function reexport(m::Module, ex::Expr)
     # unpack any macros
     ex = macroexpand(m, ex)
     # recursively unpack any blocks
     if ex.head == :block
-        ex = Base.remove_linenums!(ex)
         return Expr(:block, map(e -> reexport(m, e), ex.args)...)
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,114 +94,128 @@ using .X7
 @test Base.isexported(X7, :S7)
 
 #== Imports ==#
-module X8
+module X9
     using Reexport
 
-    module InnerX8
+    module InnerX9
         const a = 1
         export a
     end
-    @reexport import .InnerX8.a
+    @reexport import .InnerX9: a
 end
 
 module X9
     using Reexport
 
-    module InnerX9_1
+    module InnerX9
         const a = 1
         export a
     end
-
-    module InnerX9_2
-        const b = 1
-        export b
-    end
-
-    @reexport import .InnerX9_1.a, .InnerX9_2.b
+    @reexport import .InnerX9.a
 end
 
 module X10
     using Reexport
 
-    module InnerX10
+    module InnerX10_1
+        const a = 1
+        export a
+    end
+
+    module InnerX10_2
         const b = 1
         export b
     end
-    @reexport import .InnerX10
+
+    @reexport import .InnerX10_1.a, .InnerX10_2.b
+end
+
+module X11
+    using Reexport
+
+    module InnerX11
+        const b = 1
+        export b
+    end
+    @reexport import .InnerX11
 end
 
 @testset "import" begin
-    @testset "Rexported qualified single import" begin
-        @test Set(names(X8)) == Set([:X8, :a])
+    @testset "Reexported colon-qualified single import" begin
+        @test Set(names(X9)) == Set([:X9, :a])
     end
 
-    @testset "Rexported qualified multiple import" begin
-        @test Set(names(X9)) == Set([:X9, :a, :b])
+    @testset "Reexported dot-qualified single import" begin
+        @test Set(names(X9)) == Set([:X9, :a])
+    end
+
+    @testset "Reexported qualified multiple import" begin
+        @test Set(names(X10)) == Set([:X10, :a, :b])
     end
 
     @testset "Reexported module import" begin
-        @test Set(names(X10)) == Set([:X10, :InnerX10])
+        @test Set(names(X11)) == Set([:X11, :InnerX11])
     end
 end
 
 #== block ==#
-module X11
-    using Reexport
-    @reexport begin
-        using Main.X8
-        using Main.X9
-    end
-end
-
 module X12
     using Reexport
     @reexport begin
-        import Main.X8
-        import Main.X9
+        using Main.X9
+        using Main.X10
     end
 end
 
 module X13
     using Reexport
-    module InnerX13
+    @reexport begin
+        import Main.X9
+        import Main.X10
+    end
+end
+
+module X14
+    using Reexport
+    module InnerX14
         const a = 1
         export a
     end
     @reexport begin
-        import Main.X8
-        using Main.X9
-        using .InnerX13: a
+        import Main.X9
+        using Main.X10
+        using .InnerX14: a
     end
 end
 
 @testset "block" begin
     @testset "block of using" begin
-        @test Set(names(X11)) == union(Set(names(X8)), Set(names(X9)), Set([:X11]))
+        @test Set(names(X12)) == union(Set(names(X9)), Set(names(X10)), Set([:X12]))
     end
     @testset "block of import" begin
-        @test Set(names(X12)) == Set([:X12, :X8, :X9])
+        @test Set(names(X13)) == Set([:X13, :X9, :X10])
     end
     @testset "mixed using and import" begin
-        @test Set(names(X13)) == union(Set([:X13, :X8, :a]), Set(names(X9)))
+        @test Set(names(X14)) == union(Set([:X14, :X9, :a]), Set(names(X10)))
     end
 end
 
 #== macroexpand ==#
-module X14
+module X15
     using Reexport
 
     macro identity_macro(ex::Expr)
         ex
     end
 
-    module InnerX14
+    module InnerX15
         const a = 1
         export a
     end
 
-    @reexport @identity_macro using .InnerX14: a
+    @reexport @identity_macro using .InnerX15: a
 end
 @testset "macroexpand" begin
-    @test Set(names(X14)) == Set([:X14, :a])
+    @test Set(names(X15)) == Set([:X15, :a])
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,7 +94,6 @@ using .X7
 @test Base.isexported(X7, :S7)
 
 #== Imports ==#
-
 module X8
     using Reexport
 
@@ -131,7 +130,6 @@ module X10
     @reexport import .InnerX10
 end
 
-
 @testset "import" begin
     @testset "Rexported qualified single import" begin
         @test Set(names(X8)) == Set([:X8, :a])
@@ -147,7 +145,6 @@ end
 end
 
 #== block ==#
-
 module X11
     using Reexport
     @reexport begin
@@ -177,7 +174,6 @@ module X13
     end
 end
 
-
 @testset "block" begin
     @testset "block of using" begin
         @test Set(names(X11)) == union(Set(names(X8)), Set(names(X9)), Set([:X11]))
@@ -191,8 +187,6 @@ end
 end
 
 #== macroexpand ==#
-
-
 module X14
     using Reexport
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,14 +94,14 @@ using .X7
 @test Base.isexported(X7, :S7)
 
 #== Imports ==#
-module X9
+module X8
     using Reexport
 
-    module InnerX9
+    module InnerX8
         const a = 1
         export a
     end
-    @reexport import .InnerX9: a
+    @reexport import .InnerX8: a
 end
 
 module X9
@@ -142,7 +142,7 @@ end
 
 @testset "import" begin
     @testset "Reexported colon-qualified single import" begin
-        @test Set(names(X9)) == Set([:X9, :a])
+        @test Set(names(X8)) == Set([:X8, :a])
     end
 
     @testset "Reexported dot-qualified single import" begin


### PR DESCRIPTION
This pull-request is an attempt to make Reexport composable with other import macros. This idea originated from https://github.com/Roger-luo/FromFile.jl/issues/25

In order to facilitate compatibility with FromFile.jl (and potentially other import macro tools) this PR introduces the following change:

1. Any macros in the incoming expression are expanded via `Base.macroexpand`, thus `@reexport` always sees the code as if all the syntax transformations have been written out
2. `@reexport` recursively expands all `:block` expressions  (since macros like `FromFile.@from` return a block of multiple import statements)
3. Reexport is expanded to also handle statements of the form `@reexport import A.b` and `@reexport import A: b` which are transformed to `import A.b; export b` and `import A: b; export b` respectively.

Please let me know what you think about this proposal. I will add tests, once we've worked out if we want this feature at all. Also, please let me know if you prefer this pull quest to be split up into multiple smaller ones.

**Edit:**

The feature number 2 above has the nice side-effect that you can now wrap an entire block in a `@reexport` macro:
```julia
@reexport begin
    using A: b
    import C.d
end
````