### PR TITLE
Fix use of reexport inside of baremodules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Reexport"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
 authors = ["Simon Kornblith <simon@simonster.com>"]
-version = "1.2.0"
+version = "1.2.1"
 
 [compat]
 julia = "1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -219,3 +219,11 @@ end
     @test Set(names(X15)) == Set([:X15, :a])
 end
 
+baremodule B16
+    using Reexport
+    @reexport using Test
+end
+using .B16
+@testset "baremodule" begin
+    @test Base.isexported(B16, Symbol("@test"))
+end


### PR DESCRIPTION
As described in #32, the generated code from the macro included references to `Base`, which notably is not defined in `baremodule`s. We can get around this by moving the part that fetches and filters module names into its own function, ensure that gets used as a `GlobalRef` by the macro, and swap the `eval` for `Core.eval`, which is available in `baremodule`s.

Fixes #32.