### PR TITLE
Interpolate `Core.eval` in macro expression

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Reexport"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
 authors = ["Simon Kornblith <simon@simonster.com>"]
-version = "1.2.1"
+version = "1.2.2"
 
 [compat]
 julia = "1"

--- a/src/Reexport.jl
+++ b/src/Reexport.jl
@@ -38,7 +38,7 @@ function reexport(m::Module, ex::Expr)
     names = GlobalRef(@__MODULE__, :exported_names)
     out = Expr(:toplevel, ex)
     for mod in modules
-        push!(out.args, :(Core.eval($m, Expr(:export, $names($mod)...))))
+        push!(out.args, :($(Core.eval)($m, Expr(:export, $names($mod)...))))
     end
     return out
 end


### PR DESCRIPTION
Fixes the issue described in https://github.com/simonster/Reexport.jl/pull/33#issuecomment-904564731.