### PR TITLE
Add support for 4-arg `:module` form

### DIFF
--- a/src/Reexport.jl
+++ b/src/Reexport.jl
@@ -22,8 +22,9 @@ function reexport(m::Module, ex::Expr)
 
     if ex.head === :module
         # @reexport {using, import} module Foo ... end
-        modules = Any[length(ex.args) == 4 ? ex.args[3] : ex.args[2]]
-        ex = Expr(:toplevel, ex, :(using .$(ex.args[2])))
+        mod = length(ex.args) == 4 ? ex.args[3] : ex.args[2]
+        modules = Any[mod]
+        ex = Expr(:toplevel, ex, :(using .$(mod)))
     elseif ex.head::Symbol in (:using, :import) && ex.args[1].head === :(:)
         # @reexport {using, import} Foo: bar, baz
         symbols = [e.args[end] for e in ex.args[1].args[2:end]]

--- a/src/Reexport.jl
+++ b/src/Reexport.jl
@@ -22,7 +22,7 @@ function reexport(m::Module, ex::Expr)
 
     if ex.head === :module
         # @reexport {using, import} module Foo ... end
-        modules = Any[ex.args[2]]
+        modules = Any[length(ex.args) == 4 ? ex.args[3] : ex.args[2]]
         ex = Expr(:toplevel, ex, :(using .$(ex.args[2])))
     elseif ex.head::Symbol in (:using, :import) && ex.args[1].head === :(:)
         # @reexport {using, import} Foo: bar, baz


### PR DESCRIPTION
This is a new `Expr(:module, ...)` form being introduced in Julia 1.14

See https://github.com/JuliaDebug/JuliaInterpreter.jl/pull/711